### PR TITLE
fix: fix favicon refresh and stale icon after URL change

### DIFF
--- a/src/scripts/features/links/index.ts
+++ b/src/scripts/features/links/index.ts
@@ -637,7 +637,7 @@ function updateLink({ id, title, icon, url, file }: UpdateLink, data: Sync): Syn
         if (icondom && icon) {
             const img = document.createElement('img')
             const currentSrc = icondom.src
-            let url = getDefaultIcon(link.url)
+            let iconSrc = getDefaultIcon(url ?? link.url)
 
             // Icon is changing — drop any cached bytes for this link
             removeCachedIcon(id)
@@ -651,15 +651,15 @@ function updateLink({ id, title, icon, url, file }: UpdateLink, data: Sync): Syn
 
             if (icon.type === 'auto') {
                 icon.value = undefined
-                img.src = url
+                img.src = iconSrc
             }
 
             if (icon.type === 'url') {
                 if (icon.value && stringMaxSize(icon.value, 7500)) {
-                    url = icon.value
-                    img.src = url
+                    iconSrc = icon.value
+                    img.src = iconSrc
                     // Pre-warm the cache for the new URL icon
-                    cacheIconForLink(id, url)
+                    cacheIconForLink(id, iconSrc)
                 } else {
                     console.error(`There was a problem with this icon URL: ${icon.value}`)
                 }
@@ -680,8 +680,6 @@ function updateLink({ id, title, icon, url, file }: UpdateLink, data: Sync): Syn
                 }
 
                 if (file) {
-                    url = id
-
                     storeIconFile(id, file).then((uri) => {
                         img.src = uri
                     })
@@ -695,6 +693,11 @@ function updateLink({ id, title, icon, url, file }: UpdateLink, data: Sync): Syn
             link.url = stringMaxSize(url, 512)
             urldom.href = link.url
             titledom.textContent = createTitle(link)
+
+            if (link.icon?.type === 'auto') {
+                link.icon.value = undefined
+                removeCachedIcon(id)
+            }
         }
     }
 
@@ -830,9 +833,15 @@ function refreshIcons(ids: string[], data: Sync): Sync {
 
             if (!link.icon || link.icon.type === 'auto') {
                 link.icon = link.icon ?? { type: 'auto', value: '' } // when link was just added, it doesn't have the icon property, so creates it
-                link.icon.value = getDefaultIcon(link.url) + `?r=${unixDate}`
+                link.icon.value = getDefaultIcon(link.url) + `&r=${unixDate}`
             } else if (link.icon.type === 'url') {
-                link.icon.value = `${link.icon.value}?r=${unixDate}`
+                try {
+                    const u = new URL(link.icon.value ?? '')
+                    u.searchParams.set('r', unixDate)
+                    link.icon.value = u.toString()
+                } catch {
+                    // invalid URL — skip cache-busting
+                }
             }
 
             data[id] = link

--- a/src/scripts/features/links/index.ts
+++ b/src/scripts/features/links/index.ts
@@ -690,11 +690,12 @@ function updateLink({ id, title, icon, url, file }: UpdateLink, data: Sync): Syn
         }
 
         if (titledom && urldom && url !== undefined) {
+            const previousUrl = link.url
             link.url = stringMaxSize(url, 512)
             urldom.href = link.url
             titledom.textContent = createTitle(link)
 
-            if (link.icon?.type === 'auto') {
+            if (link.icon?.type === 'auto' && link.url !== previousUrl) {
                 link.icon.value = undefined
                 removeCachedIcon(id)
             }
@@ -840,7 +841,9 @@ function refreshIcons(ids: string[], data: Sync): Sync {
                     u.searchParams.set('r', unixDate)
                     link.icon.value = u.toString()
                 } catch {
-                    // invalid URL — skip cache-busting
+                    // Fallback for relative or non-standard URLs
+                    const value = link.icon.value ?? ''
+                    link.icon.value = value.includes('?') ? `${value}&r=${unixDate}` : `${value}?r=${unixDate}`
                 }
             }
 


### PR DESCRIPTION
## Problem

When using the **Favicon** icon option for a link, two bugs made the feature unreliable:

### Bug 1 — "Refresh icon" button shows a broken/error icon

Clicking "Refresh icon" in the link editor immediately replaced the favicon with an error/fallback icon that never resolved.

<img width="331" height="225" alt="image" src="https://github.com/user-attachments/assets/74ae2ce7-b27e-4d58-a884-c8c2fff62a3a" />



**Root cause:** `getDefaultIcon()` returns a URL that already contains a `?` (e.g. `https://www.google.com/s2/favicons?domain=...&sz=128`). The `refreshIcons` function appended `?r=<timestamp>` to cache-bust the URL, producing a malformed URL with two question marks:

```
https://www.google.com/s2/favicons?domain=example.com&sz=128?r=1234567890
```

This caused the request to return a 404, which triggered the `img.onerror` handler and displayed the fallback icon permanently.

### Bug 2 — Changing the link URL still shows the old domain's favicon

After editing a link and changing its URL to a different domain, clicking **Apply changes** continued to display the favicon from the original domain. The new domain's favicon only appeared after manually clicking "Refresh icon".

**Root cause:** `link.icon.value` stored the stale favicon URL from a previous refresh or session. When `updateLink` ran, it read this cached value via `getIconFromLinkElem` and rendered it instead of fetching the favicon for the new URL. Neither `link.icon.value` was cleared nor the cache entry dropped on URL change.

A secondary issue in `updateLink` shadowed the `url` parameter with a local `let url` variable, causing `getDefaultIcon` to always use the old stored URL when computing the default icon source — so even newly applied URL changes weren't reflected until a manual refresh.

---

## Fix

- **`refreshIcons`**: Changed `?r=` to `&r=` for `auto`-type icons so the cache-buster is appended as a query parameter rather than starting a second query string. For `url`-type icons, switched to `URL.searchParams.set()` to handle cache-busting correctly regardless of the existing URL structure.

- **`updateLink`**: Renamed local variable `url` → `iconSrc` to stop it shadowing the `url` function parameter. Changed `getDefaultIcon(link.url)` to `getDefaultIcon(url ?? link.url)` so the freshly entered URL from the form is used immediately when computing the default favicon.

- **`updateLink`**: When the link URL changes and the icon type is `auto`, `link.icon.value` is now cleared to `undefined` and `removeCachedIcon` is called. This ensures the next render fetches the correct favicon for the new domain instead of serving the stale cached value.

---

> Note: This fix was co-authored with GitHub Copilot

## TL:DR / Human-written summary

- There was a couple of bugs in the favicon displaying, first when you changed icon display to favicon and applied, nothing changed, and when you right-clicked again and pressed "refresh icon" you got fed a error-icon. The correct favicon would only load if you changed to a new URL for the link, displaying the _old_ links favicon.
- Now with the bug fixed, I added a small change as well so that when editing a link and changing the icon source to favicon, the new favicon gets fetched when you press "apply changes", not having to again press "refresh icon" after that.
- Setup the bug was discovered on: MacOS 26, Edge Browser.